### PR TITLE
separate example using view for more efficeint memory,

### DIFF
--- a/examples/ps3eye.jl
+++ b/examples/ps3eye.jl
@@ -12,11 +12,15 @@ function displaylive!(im1, vidchan)
 end
 
 # This colour mapping may be wrong for the PS3eye.
-ycrcb = Video4Linux.UYVY(640,480)
-vidchan = Channel((c::Channel) -> videoproducer(c, ycrcb, devicename = "/dev/video1", iomethod = Video4Linux.IO_METHOD_MMAP ))
+ycrcb = Video4Linux.YUYV(640,480)
+vidchan = Channel((c::Channel) -> videoproducer(c, ycrcb, devicename = "/dev/video0", iomethod = Video4Linux.IO_METHOD_MMAP ))
 
 ##
 #capture one frame to create im1 and canvas needed to diplay
 A =  take!(vidchan)
 im1 = RGB.(YCbCr.(view(A,:,:,1), view(A,:,:,2), view(A,:,:,3)))
 canvas = imshow(im1)
+
+while isopen(vidchan)
+    displaylive!(im1, vidchan)
+end

--- a/examples/ps3eye.jl
+++ b/examples/ps3eye.jl
@@ -1,0 +1,22 @@
+using Images, ImageView
+using Video4Linux
+
+
+
+function displaylive!(im1, vidchan)
+
+    A =  take!(vidchan)
+    im1 = RGB.(YCbCr.(A[:,:,1], A[:,:,2], A[:,:,3]))
+    imshow(canvas["gui"]["canvas"], im1)
+
+end
+
+# This colour mapping may be wrong for the PS3eye.
+ycrcb = Video4Linux.UYVY(640,480)
+vidchan = Channel((c::Channel) -> videoproducer(c, ycrcb, devicename = "/dev/video1", iomethod = Video4Linux.IO_METHOD_MMAP ))
+
+##
+#capture one frame to create im1 and canvas needed to diplay
+A =  take!(vidchan)
+im1 = RGB.(YCbCr.(view(A,:,:,1), view(A,:,:,2), view(A,:,:,3)))
+canvas = imshow(im1)

--- a/src/encodings.jl
+++ b/src/encodings.jl
@@ -176,6 +176,21 @@ function (decoder::UYVY)(im444::Array{UInt8,3})
 end
 
 
+struct YUYV <: AbstractEncodings
+    width::Int
+    height::Int
+    depth::Int
+    datatype::DataType
+end
+YUYV(width::Int, height::Int) = YUYV(width, height, 3, UInt8)
+
+function (decoder::YUYV)(im444::Array{UInt8,3})
+    imbuff = copy_buffer_bytes(decoder.width * decoder.height * 2)
+    im444[:] = convertYUYVtoArray(imbuff, decoder.width, decoder.height)
+    return nothing
+end
+
+
 struct Y10B <: AbstractEncodings
     width::Int
     height::Int


### PR DESCRIPTION
- colour map is still wrong, but likely relating to the camera driver and the mapping of bits and colours.

@Affie, note the use of `view(A, :, :, 1)` over `A[:,:,1]` to avoid allocating more memory. See more [documentation on views here](https://docs.julialang.org/en/stable/stdlib/arrays/#Views-(SubArrays-and-other-view-types)-1).

EDIT:
![v4l_jl_ps3_img](https://user-images.githubusercontent.com/6412556/33796830-80d2b7d2-dcca-11e7-82dc-3436c81955bb.png)